### PR TITLE
Improving error reporting regarding stackoverflows and making easier running on 32 bit systems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,12 @@
         <outputDirectory>target/classes</outputDirectory>
         <resources>
             <resource>
-                <directory>resources</directory>
+                <directory>shen</directory>
+                <excludes>
+                    <exclude>benchmarks/</exclude>
+                    <exclude>src/</exclude>
+                    <exclude>Test Programs/</exclude>
+                </excludes>
             </resource>
         </resources>
         <plugins>

--- a/resources/klambda
+++ b/resources/klambda
@@ -1,1 +1,0 @@
-../shen/klambda

--- a/shen.java
+++ b/shen.java
@@ -5,4 +5,4 @@ java="$rlwrap $JAVA_HOME/bin/java $JAVA_OPTS"
 shen="find . -name shen.java-*.jar"
 
 test -z `$shen` && mvn package
-$java -jar `$shen`
+$java -Xss500k -jar `$shen`

--- a/src/shen/Shen.java
+++ b/src/shen/Shen.java
@@ -694,7 +694,15 @@ public class Shen {
             } finally {
                 lines.clear();
                 try (OutputStream out = new FileOutputStream(classFile)) {
-                    out.write(compiler.bytes);
+                    if(compiler.bytes == null){
+                        out.close();
+                        classFile.delete();
+                        throw new Exception("Shen.compile : trying to write zero bytes out to the file " + file +
+                        ".class. This has happened because a stackoverflow has taken place." +
+                        " Try increasing default stack size via the -Xss option.");
+                    }else{
+                        out.write(compiler.bytes);
+                    }
                 }
             }
         }


### PR DESCRIPTION
1)Making changes to the pom.xml file in order to allow one to run the program on windows XP (from within IntelliJ). The problem with previous version was that the symbolic link in the resources folder would not work on windows XP

2)Previously the Shen.compile function was encountering a stackoverflow on 32 bit systems. Irrespective of this the "finally" block was trying to output the contents of a null reference (compiler.bytes) to a file, thus creating an empty declarations.class file. Upon a second running of the program, this empty file was detected and loaded. Thus even if one appropriately increased the stack size, the program would still fail.

Now an error message is reported, and furthermore if compiler.bytes is a null reference, an empty .class file is not created.

3)Changed the scripts to allow ./build to work on 32 bit linux.
