### PR TITLE
Changes regarding *home-directory* variable and the Primitives.open function

### DIFF
--- a/shen.java.iml
+++ b/shen.java.iml
@@ -5,7 +5,7 @@
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/resources" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/shen" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>

--- a/src/shen/Shen.java
+++ b/src/shen/Shen.java
@@ -535,15 +535,11 @@ public class Shen {
             if (!"file".equals(type.symbol)) throw new IllegalArgumentException("invalid stream type");
             //noinspection RedundantCast
 
-            //If "string" contains a separator, then we assume that the absolute
-            //path of the file has been specified. Otherwise we assume that the file
-            //resides in the home directory
-            File file;
-            if(string.contains(File.separator)){
-                file = new File("", string);
-            }else{
+            File file = new File(string);
+            if(!file.isAbsolute()){
                 file = new File((String) intern("*home-directory*").value(), string);
             }
+
             switch (direction.symbol) {
                 case "in": return new BufferedInputStream(new FileInputStream(file));
                 case "out": return new BufferedOutputStream(new FileOutputStream(file));

--- a/src/shen/Shen.java
+++ b/src/shen/Shen.java
@@ -534,7 +534,16 @@ public class Shen {
         public static Closeable open(Symbol type, String string, Symbol direction) throws IOException {
             if (!"file".equals(type.symbol)) throw new IllegalArgumentException("invalid stream type");
             //noinspection RedundantCast
-            File file = new File((String) intern("*home-directory*").value(), string);
+
+            //If "string" contains a separator, then we assume that the absolute
+            //path of the file has been specified. Otherwise we assume that the file
+            //resides in the home directory
+            File file;
+            if(string.contains(File.separator)){
+                file = new File("", string);
+            }else{
+                file = new File((String) intern("*home-directory*").value(), string);
+            }
             switch (direction.symbol) {
                 case "in": return new BufferedInputStream(new FileInputStream(file));
                 case "out": return new BufferedOutputStream(new FileOutputStream(file));
@@ -652,6 +661,7 @@ public class Shen {
                 "prolog", "track", "load", "writer", "macros", "declarations", "types", "t-star"))
             load("klambda/" + file, Callable.class).newInstance().call();
         set("shen-*installing-kl*", false);
+        set("*home-directory*", getProperty("user.dir"));//Resetting it because it gets overwritten in declarations.kl
         builtins.addAll(vec(symbols.values().stream().filter(s -> !s.fn.isEmpty())));
     }
 


### PR DESCRIPTION
1)_home-directory_ was being overwritten during the loading of the declarations.kl file. As a result intern("_home-directory_").value() was returning an empty string upon a call of the "load" function (after the declarations.kl file had been loaded). This meant that in order to "load" a file the absolute path was required.

Changed the code so that _home-directory_ points to the home directory even after loading of the declarations.kl.

2)Made changes to Primitives.open function so that it detects whether one is specifying absolute path or not, and appropriately handles each case.
